### PR TITLE
Add support for addon managers like Snapjaw

### DIFF
--- a/ActionBarProfiles.toc
+++ b/ActionBarProfiles.toc
@@ -1,3 +1,4 @@
+## Interface: 11200
 ## Title: ActionBarProfiles
 ## Notes: Save and load action bar profiles
 ## Author: Ermean <Vanguard>, Emerald Dream 1.12.1, Feenix, Sivent


### PR DESCRIPTION
Attempting to install this addon using Snapjaw will fail with an error saying no vanilla addon was found. Declaring the addon interface fixes this.

Before:
```
$ snapjaw.exe install https://github.com/Siventt/ActionBarProfiles
error: no vanilla addons found
```

After:
```
$ snapjaw.exe install https://github.com/Kangaroux/ActionBarProfiles/tree/kangaroux/add-interface-version-to-toc
2024-04-27 17:21:46,681 [INFO] Installing addon "ActionBarProfiles", branch "kangaroux/add-interface-version-to-toc"
2024-04-27 17:21:46,697 [INFO] Done
2024-04-27 17:21:46,704 [INFO] Saving config...
2024-04-27 17:21:46,708 [INFO] Done!
```